### PR TITLE
Add star field and optional starry background

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,29 @@ socket.on('connect', () => { playerId = socket.id; });
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);
 
+// generate starfield
+const starGeometry = new THREE.BufferGeometry();
+const starCount = 1000;
+const starVertices = [];
+for (let i = 0; i < starCount; i++) {
+  const x = THREE.MathUtils.randFloatSpread(200);
+  const y = THREE.MathUtils.randFloatSpread(200);
+  const z = THREE.MathUtils.randFloatSpread(200);
+  starVertices.push(x, y, z);
+}
+starGeometry.setAttribute('position', new THREE.Float32BufferAttribute(starVertices, 3));
+const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.5 });
+const stars = new THREE.Points(starGeometry, starMaterial);
+scene.add(stars);
+
+// optional starfield background
+new THREE.TextureLoader().load(
+  'https://raw.githubusercontent.com/mrdoob/three.js/master/examples/textures/galaxy_starfield.png',
+  texture => {
+    scene.background = texture;
+  }
+);
+
 const camera = new THREE.PerspectiveCamera(
   75, window.innerWidth / window.innerHeight, 0.1, 1000
 );


### PR DESCRIPTION
## Summary
- Populate scene with 1000 randomly positioned stars using `THREE.Points`
- Optionally load a starfield texture to use as the scene background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc6ac4cd88331a23a72133be32268