### PR TITLE
Add interactive health bar to HUD

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -50,10 +50,27 @@
       width:20px;
       height:2px;
     }
+
+    #healthBar {
+      position:absolute;
+      bottom:20px;
+      left:50%;
+      transform:translateX(-50%);
+      width:200px;
+      height:20px;
+      border:1px solid #fff;
+      background:rgba(255,255,255,0.1);
+    }
+
+    #healthFill {
+      height:100%;
+      width:100%;
+      background:#0f0;
+    }
   </style>
 </head>
 <body>
-<div id="hud"><div id="hudText"></div><div class="crosshair"></div></div>
+<div id="hud"><div id="hudText"></div><div class="crosshair"></div><div id="healthBar"><div id="healthFill"></div></div></div>
 <script src="/socket.io/socket.io.js"></script>
 <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
 <script src="main.js"></script>

--- a/client/main.js
+++ b/client/main.js
@@ -4,6 +4,13 @@ socket.on('connect', () => { playerId = socket.id; });
 
 const hud = document.getElementById('hud');
 const hudText = document.getElementById('hudText');
+const healthFill = document.getElementById('healthFill');
+
+let health = 100;
+function updateHealth(){
+  healthFill.style.width = health + '%';
+}
+updateHealth();
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);
@@ -87,7 +94,13 @@ socket.on('playerLeft', (id) => {
 });
 
 const keys = {};
-document.addEventListener('keydown', (e) => { keys[e.key.toLowerCase()] = true; });
+document.addEventListener('keydown', (e) => {
+  keys[e.key.toLowerCase()] = true;
+  if(e.key === ' '){
+    health = Math.max(0, health - 10);
+    updateHealth();
+  }
+});
 document.addEventListener('keyup', (e) => { keys[e.key.toLowerCase()] = false; });
 
 let yaw = 0;
@@ -111,6 +124,11 @@ window.addEventListener('resize', () => {
 function animate(){
   requestAnimationFrame(animate);
   const speed = 0.2;
+
+  if(health < 100){
+    health = Math.min(100, health + 0.05);
+    updateHealth();
+  }
 
   if (keys['w'] || keys['arrowup']) ship.translateZ(-speed);
   if (keys['s'] || keys['arrowdown']) ship.translateZ(speed);


### PR DESCRIPTION
## Summary
- add health bar HTML and styles to HUD
- decrease health when pressing space key and regenerate over time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce0faef4083319364f8a87d8f4b4c