### PR TITLE
Add in-game HUD menu with ship info, map, market, and targets

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,6 @@
       width:100%;
       height:100%;
       color:#fff;
-      pointer-events:none;
       font-family:sans-serif;
       z-index:10;
     }
@@ -29,6 +28,7 @@
       height:20px;
       margin-left:-10px;
       margin-top:-10px;
+      pointer-events:none;
     }
     .crosshair:before,
     .crosshair:after {
@@ -67,10 +67,45 @@
       width:100%;
       background:#0f0;
     }
+
+    #menuToggle {
+      position:absolute;
+      top:10px;
+      right:10px;
+      pointer-events:auto;
+    }
+
+    #menu {
+      position:absolute;
+      top:50px;
+      right:10px;
+      width:300px;
+      max-height:400px;
+      overflow:auto;
+      background:rgba(0,0,0,0.8);
+      border:1px solid #fff;
+      padding:10px;
+      pointer-events:auto;
+    }
+
+    .hidden { display:none; }
+
+    #menu > div { margin-bottom:10px; }
   </style>
 </head>
 <body>
-<div id="hud"><div id="hudText"></div><div class="crosshair"></div><div id="healthBar"><div id="healthFill"></div></div></div>
+<div id="hud">
+  <div id="hudText"></div>
+  <button id="menuToggle">Menu</button>
+  <div id="menu" class="hidden">
+    <div id="ship-info"></div>
+    <div id="galactic-map"></div>
+    <div id="market"></div>
+    <div id="targets"></div>
+  </div>
+  <div class="crosshair"></div>
+  <div id="healthBar"><div id="healthFill"></div></div>
+</div>
 <script src="/socket.io/socket.io.js"></script>
 <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
 <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- Add toggleable in-game menu with tabs for ship info, galactic map, market, and nearby targets
- Populate menu with ship stats, rendered star/player map, inventory fetch, and distance calculations
- Style HUD menu and enable keyboard/button toggling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce310437c83318a8ae26a30340063