### PR TITLE
Add login page and shared styling

### DIFF
--- a/client/login.html
+++ b/client/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login - Space MMORPG</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="login-background">
+  <div class="login-container">
+    <form id="loginForm" class="login-form">
+      <h1>Login</h1>
+      <input type="text" id="username" placeholder="Username" required />
+      <input type="password" id="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+      <p id="error" class="error-msg"></p>
+    </form>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/client/login.js
+++ b/client/login.js
@@ -1,0 +1,27 @@
+const form = document.getElementById('loginForm');
+const errorEl = document.getElementById('error');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value.trim();
+
+  try {
+    const res = await fetch('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      window.location.href = 'index.html';
+    } else {
+      const err = await res.json();
+      errorEl.textContent = err.error || 'Login failed';
+    }
+  } catch (err) {
+    errorEl.textContent = 'Login failed';
+  }
+});

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,4 +1,10 @@
-body { margin:0; overflow:hidden; }
+body {
+  margin:0;
+  overflow:hidden;
+  font-family:'Roboto', sans-serif;
+  background:#000;
+  color:#fff;
+}
 
 #hud {
   position:absolute;
@@ -85,5 +91,60 @@ body { margin:0; overflow:hidden; }
     width:15px;
     height:15px;
   }
+}
+
+
+.login-background {
+  background:url('https://raw.githubusercontent.com/mrdoob/three.js/master/examples/textures/galaxy_starfield.png') center/cover no-repeat fixed;
+}
+
+.login-container {
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  height:100vh;
+}
+
+.login-form {
+  background:rgba(0,0,0,0.7);
+  padding:20px;
+  border-radius:8px;
+  box-shadow:0 0 10px rgba(255,255,255,0.2);
+  width:300px;
+  text-align:center;
+}
+
+.login-form h1 {
+  margin-top:0;
+  margin-bottom:20px;
+  font-weight:500;
+}
+
+.login-form input {
+  width:100%;
+  padding:10px;
+  margin-bottom:10px;
+  border:none;
+  border-radius:4px;
+}
+
+.login-form button {
+  width:100%;
+  padding:10px;
+  border:none;
+  border-radius:4px;
+  background:#2194ce;
+  color:#fff;
+  font-size:16px;
+  cursor:pointer;
+}
+
+.login-form button:hover {
+  background:#1b7aa7;
+}
+
+.error-msg {
+  color:#f66;
+  min-height:1em;
 }
 


### PR DESCRIPTION
## Summary
- Add login page with styled background and form
- Handle login requests and redirect to game on success
- Extend global stylesheet for consistent typography and login layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ceddc2f508331815b531f06dede2e